### PR TITLE
Added HybridConnection for UI/API combos

### DIFF
--- a/Vermaat.Crm.Specflow.Sample/app.config
+++ b/Vermaat.Crm.Specflow.Sample/app.config
@@ -20,6 +20,7 @@
     <add key="TimeFormat" value="H:mm" />
     <add key="DateFormat" value="d-M-yyyy" />
     <add key="AsyncJobTimeoutInSeconds" value="20" />
+    
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/Vermaat.Crm.Specflow/Connectivity/HybridCrmConnection.cs
+++ b/Vermaat.Crm.Specflow/Connectivity/HybridCrmConnection.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.Dynamics365.UIAutomation.Browser;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vermaat.Crm.Specflow.EasyRepro;
+
+namespace Vermaat.Crm.Specflow.Connectivity
+{
+    public class HybridCrmConnection : CrmConnection
+    {
+        private readonly string _authType;
+        private readonly BrowserLoginDetails _browserLoginDetails;
+        private readonly string _clientId;
+        private readonly string _clientSecret;
+
+        public HybridCrmConnection(string clientId, string clientSecret, string browserUsername, string browserPassword)
+            : base(browserUsername)
+        {
+            _authType = HelperMethods.GetAppSettingsValue("AuthType", false);
+            _clientId = clientId;
+            _clientSecret = clientSecret;
+            _browserLoginDetails = new BrowserLoginDetails
+            {
+                Url = HelperMethods.GetAppSettingsValue("Url", false),
+                Username = browserUsername,
+                Password = browserPassword.ToSecureString()
+            };
+        }
+
+        public static HybridCrmConnection CreateFromAppConfig()
+        {
+            return new HybridCrmConnection(
+                HelperMethods.GetAppSettingsValue("ClientId", false),
+                HelperMethods.GetAppSettingsValue("ClientSecret", false),
+                HelperMethods.GetAppSettingsValue("Username", false),
+                HelperMethods.GetAppSettingsValue("Password", false));
+        }
+
+        public static HybridCrmConnection CreateAdminConnectionFromAppConfig()
+        {
+            var clientId = HelperMethods.GetAppSettingsValue("AdminClientId", true) ?? HelperMethods.GetAppSettingsValue("ClientId");
+            var clientSecret = HelperMethods.GetAppSettingsValue("AdminClientSecret", true) ?? HelperMethods.GetAppSettingsValue("ClientSecret");
+            var username = HelperMethods.GetAppSettingsValue("AdminUsername", true) ?? HelperMethods.GetAppSettingsValue("Username");
+            var password = HelperMethods.GetAppSettingsValue("AdminPassword", true) ?? HelperMethods.GetAppSettingsValue("Password");
+            return new HybridCrmConnection(clientId, clientSecret, username, password);
+        }
+
+        public override CrmService CreateCrmServiceInstance()
+        {
+            return new CrmService($"AuthType={_authType};Url={_browserLoginDetails.Url};ClientId={_clientId};ClientSecret={_clientSecret};RequireNewInstance=True");
+        }
+
+        public override BrowserLoginDetails GetBrowserLoginInformation()
+        {
+            throw new TestExecutionException(Constants.ErrorCodes.APPLICATIONUSER_CANNOT_LOGIN);
+        }
+    }
+}

--- a/Vermaat.Crm.Specflow/Hooks.cs
+++ b/Vermaat.Crm.Specflow/Hooks.cs
@@ -98,19 +98,29 @@ namespace Vermaat.Crm.Specflow
         [BeforeScenario]
         public void SetDefaultConnection()
         {
-            var authType = HelperMethods.GetAppSettingsValue("AuthType", true);
+            // Fallback to 'Default' for backwards compatibility
+            var loginType = HelperMethods.GetAppSettingsValue("LoginType", true) ?? "Default";
 
             CrmConnection connection;
             CrmConnection adminConnection;
-            if (authType.Equals("ClientSecret", StringComparison.InvariantCultureIgnoreCase))
+            switch (loginType)
             {
-                connection = ClientSecretCrmConnection.CreateFromAppConfig();
-                adminConnection = ClientSecretCrmConnection.CreateAdminConnectionFromAppConfig();
-            }
-            else
-            {
-                connection = UsernamePasswordCrmConnection.FromAppConfig();
-                adminConnection = UsernamePasswordCrmConnection.AdminConnectionFromAppConfig();
+                case "Default":
+                    connection = UsernamePasswordCrmConnection.FromAppConfig();
+                    adminConnection = UsernamePasswordCrmConnection.AdminConnectionFromAppConfig();
+                    break;
+                case "ClientSecret":
+                    connection = ClientSecretCrmConnection.CreateFromAppConfig();
+                    adminConnection = ClientSecretCrmConnection.CreateAdminConnectionFromAppConfig();
+                    break;
+                case "Hybrid":
+                    connection = HybridCrmConnection.CreateFromAppConfig();
+                    adminConnection = HybridCrmConnection.CreateAdminConnectionFromAppConfig();
+                    break;
+                // Implementations can add their own 'LoginType'. If this is done, then this method shouldn't do anything
+                default: 
+                    return;
+
             }
 
             GlobalTestingContext.ConnectionManager.SetAdminConnection(adminConnection);


### PR DESCRIPTION
Fixes #85 

I added a new config variable 'LoginType' to specify what connection to use. Basing it on the AuthType isn't correct. UI tests may still use some API calls, so also a hybrid connection is needed (username/password for browser and a related clientid/clientsecret for API calls).

If needed anybody can add additional logintypes and create their own hook to set it up correctly. 