### PR TITLE
Fixed MS

### DIFF
--- a/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
@@ -22,7 +22,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
             { SeleniumSelectorItems.Entity_SubGrid_Button, ".//button[contains(@data-id,'[NAME]')]" },
             { SeleniumSelectorItems.FlyoutRoot, "//div[@id='__flyoutRootNode']" },
             { SeleniumSelectorItems.Entity_ScriptErrorDialog, "//*[@id='dialogTitleText']" },
-            { SeleniumSelectorItems.Entity_FormLoad, "id(\"tablist\")" },
+            { SeleniumSelectorItems.Entity_FormLoad, "//ul[contains(@id, 'tablist_')]" },
             { SeleniumSelectorItems.Entity_MoreTabs, ".//button[@data-id='more_button']" },
             { SeleniumSelectorItems.Entity_DateContainer, "//div[contains(@data-id,'[NAME].fieldControl._datecontrol-date-container')]" },
             { SeleniumSelectorItems.Entity_DateTime_Time_Input, "//input[@id='[NAME]_fabric_combobox-input']" },

--- a/Vermaat.Crm.Specflow/Hooks.cs
+++ b/Vermaat.Crm.Specflow/Hooks.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics365.UIAutomation.Browser;
+﻿using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+using Microsoft.Dynamics365.UIAutomation.Browser;
 using OpenQA.Selenium;
 using System;
 using System.Collections.Generic;
@@ -26,6 +27,15 @@ namespace Vermaat.Crm.Specflow
             _crmContext = crmContext;
             _featureContext = featureContext;
             _scenarioContext = scenarioContext;
+        }
+
+        /// <summary>
+        /// This is a temporary fix as due to another issue EasyRepro can't be updated right now
+        /// </summary>
+        [BeforeScenario]
+        public void FixXPaths()
+        {
+            AppElements.Xpath[AppReference.Entity.TabList] = "//ul[contains(@id, \"tablist\")]";
         }
 
         [BeforeScenario("API")]


### PR DESCRIPTION
Microsoft changed the HTML element for tabs causing form load timeouts and no longer able to change tabs. The fix for the XPaths is a patch to make it work again. I will do a good fix later after managing to fix another more complex issue that occurs when updating EasyRepro