### PR TITLE
Feature/specflow35

### DIFF
--- a/Deployment/Pipelines/Build_NuGet.yml
+++ b/Deployment/Pipelines/Build_NuGet.yml
@@ -44,9 +44,10 @@ steps:
   displayName: 'NuGet push'
   condition: and(succeeded(), eq(variables.CreateNuGetPackage, 'true'))
   inputs:
-    command: push
-    nuGetFeedType: external
-    publishFeedCredentials: NuGet.org
+    command: 'push'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+    nuGetFeedType: 'external'
+    publishFeedCredentials: 'NuGet - MVermaat'
 
 - task: CopyFiles@2
   displayName: 'Copy Files to: $(build.artifactstagingdirectory)'

--- a/Deployment/Pipelines/Build_SampleSolution.yml
+++ b/Deployment/Pipelines/Build_SampleSolution.yml
@@ -112,7 +112,7 @@ stages:
           - task: MSCRMImportSolution@11
             displayName: 'Import SpecFlowDemo'
             inputs:
-              crmConnectionString: 'Url=$(Url);AuthType=$(AuthType);Username=$(Username);Password=$(Password)'
+              crmConnectionString: 'Url=$(Url);AuthType=$(AuthType);ClientId=$(ClientId);ClientSecret=$(ClientSecret)'
               solutionFile: '$(Agent.BuildDirectory)/SampleSolution/Solution/SpecFlowDemo_managed.zip'
               publishWorkflows: true
               overwriteUnmanagedCustomizations: true
@@ -121,13 +121,13 @@ stages:
           - task: MSCRMApplySolution@10
             displayName: 'Apply SpecFlowDemo'
             inputs:
-              crmConnectionString: 'Url=$(Url);AuthType=$(AuthType);Username=$(Username);Password=$(Password)'
+              crmConnectionString: 'Url=$(Url);AuthType=$(AuthType);ClientId=$(ClientId);ClientSecret=$(ClientSecret)'
               solutionName: 'SpecFlowDemo'
               useAsyncMode: true
 
           - task: MSCRMImportCMData@9
             inputs:
-              crmConnectionString: 'Url=$(Url);AuthType=$(AuthType);Username=$(Username);Password=$(Password)'
+              crmConnectionString: 'Url=$(Url);AuthType=$(AuthType);ClientId=$(ClientId);ClientSecret=$(ClientSecret)'
               dataFile: '$(Agent.BuildDirectory)/SampleSolution/Data/CMData.zip'
 
           - task: PowerShell@2

--- a/Deployment/Pipelines/Build_SampleSolution.yml
+++ b/Deployment/Pipelines/Build_SampleSolution.yml
@@ -134,7 +134,7 @@ stages:
             displayName: 'Update AppSettings.config'
             inputs:
               filePath: '$(Agent.BuildDirectory)/SampleSolution/Scripts/UpdateAppSettings.ps1'
-              arguments: '-url $(Url) -username $(Username) -password $(Password) -clientId $(ClientId) -clientSecret $(ClientSecret) -appsettingsPath "$(Agent.BuildDirectory)/SampleSolution/SpecFlow/appsettings.config"'
+              arguments: '-url $(Url) -username $(Username) -password $(Password) -clientId $(ClientId) -clientSecret $(ClientSecret) -authType $(AuthType) -appsettingsPath "$(Agent.BuildDirectory)/SampleSolution/SpecFlow/appsettings.config"'
           
           - task: VSTest@2
             displayName: 'Run SpecFlow Tests - API'

--- a/Deployment/Pipelines/Build_SampleSolution.yml
+++ b/Deployment/Pipelines/Build_SampleSolution.yml
@@ -134,7 +134,7 @@ stages:
             displayName: 'Update AppSettings.config'
             inputs:
               filePath: '$(Agent.BuildDirectory)/SampleSolution/Scripts/UpdateAppSettings.ps1'
-              arguments: '-url $(Url) -username $(Username) -password $(Password) -appsettingsPath "$(Agent.BuildDirectory)/SampleSolution/SpecFlow/appsettings.config"'
+              arguments: '-url $(Url) -username $(Username) -password $(Password) -clientId $(ClientId) -clientSecret $(ClientSecret) -appsettingsPath "$(Agent.BuildDirectory)/SampleSolution/SpecFlow/appsettings.config"'
           
           - task: VSTest@2
             displayName: 'Run SpecFlow Tests - API'

--- a/Deployment/Pipelines/Build_SampleSolution.yml
+++ b/Deployment/Pipelines/Build_SampleSolution.yml
@@ -91,7 +91,7 @@ stages:
     pool:
       vmImage: 'windows-latest'
     variables:
-    - group: 'TST'
+    - group: 'TST - New'
     environment: 'TST'
     strategy:
       runOnce:

--- a/Deployment/Scripts/CreateAppSettings.ps1
+++ b/Deployment/Scripts/CreateAppSettings.ps1
@@ -5,7 +5,7 @@ param(
 
 ######################### Script #########################
 $output = "<appSettings>" +
-"<add key=""AuthType"" value=""Office365"" />" +
+"<add key=""AuthType"" value="""" />" +
 "<add key=""Url"" value="""" />" +
 "<add key=""Username"" value="""" />" +
 "<add key=""Password"" value="""" />" +

--- a/Deployment/Scripts/CreateAppSettings.ps1
+++ b/Deployment/Scripts/CreateAppSettings.ps1
@@ -9,6 +9,8 @@ $output = "<appSettings>" +
 "<add key=""Url"" value="""" />" +
 "<add key=""Username"" value="""" />" +
 "<add key=""Password"" value="""" />" +
+"<add key=""ClientId"" value="""" />" +
+"<add key=""ClientSecret"" value="""" />" +
 "</appSettings>"
 
 Out-File -FilePath $outputpath -InputObject $output

--- a/Deployment/Scripts/UpdateAppSettings.ps1
+++ b/Deployment/Scripts/UpdateAppSettings.ps1
@@ -3,6 +3,8 @@ param(
 [string]$url,
 [string]$username,
 [string]$password,
+[string]$clientId,
+[string]$clientSecret,
 [string]$appsettingsPath
 )
 
@@ -20,9 +22,13 @@ Write-Host "Full Path: $fullPath"
 $urlNode = ($content.appSettings.add | where { $_.key -eq "Url" })
 $usernameNode = ($content.appSettings.add | where { $_.key -eq "Username" })
 $passwordNode = ($content.appSettings.add | where { $_.key -eq "Password" })
+$clientIdNode = ($content.appSettings.add | where { $_.key -eq "ClientId" })
+$clientSecretNode = ($content.appSettings.add | where { $_.key -eq "ClientSecret" })
 
 $urlNode.value = $url
 $usernameNode.value = $username
 $passwordNode.value = $password
+$clientIdNode.value = $clientId
+$clientSecretNode.value = $clientSecret
 
 $content.Save($fullPath)

--- a/Deployment/Scripts/UpdateAppSettings.ps1
+++ b/Deployment/Scripts/UpdateAppSettings.ps1
@@ -5,6 +5,7 @@ param(
 [string]$password,
 [string]$clientId,
 [string]$clientSecret,
+[string]$authType,
 [string]$appsettingsPath
 )
 
@@ -24,11 +25,14 @@ $usernameNode = ($content.appSettings.add | where { $_.key -eq "Username" })
 $passwordNode = ($content.appSettings.add | where { $_.key -eq "Password" })
 $clientIdNode = ($content.appSettings.add | where { $_.key -eq "ClientId" })
 $clientSecretNode = ($content.appSettings.add | where { $_.key -eq "ClientSecret" })
+$authTypeNode = ($content.appSettings.add | where { $_.key -eq "AuthType" })
+
 
 $urlNode.value = $url
 $usernameNode.value = $username
 $passwordNode.value = $password
 $clientIdNode.value = $clientId
 $clientSecretNode.value = $clientSecret
+$authTypeNode.value = $authType
 
 $content.Save($fullPath)

--- a/Vermaat.Crm.Specflow.Sample/Vermaat.Crm.Specflow.Sample.csproj
+++ b/Vermaat.Crm.Specflow.Sample/Vermaat.Crm.Specflow.Sample.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="87.0.4280.8800" />
-    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.26.0.1" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.0.225" />
-    <PackageReference Include="SpecRun.SpecFlow.3-0-0" Version="3.0.377" />
+    <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.29.0" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.5.14" />
+    <PackageReference Include="SpecRun.SpecFlow" Version="3.5.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Vermaat.Crm.Specflow.Sample/Vermaat.Crm.Specflow.Sample.csproj
+++ b/Vermaat.Crm.Specflow.Sample/Vermaat.Crm.Specflow.Sample.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Selenium.Chrome.WebDriver" Version="85.0.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="87.0.4280.8800" />
     <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.26.0.1" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.0.225" />
     <PackageReference Include="SpecRun.SpecFlow.3-0-0" Version="3.0.377" />

--- a/Vermaat.Crm.Specflow.Sample/app.config
+++ b/Vermaat.Crm.Specflow.Sample/app.config
@@ -20,7 +20,7 @@
     <add key="TimeFormat" value="H:mm" />
     <add key="DateFormat" value="d-M-yyyy" />
     <add key="AsyncJobTimeoutInSeconds" value="20" />
-    
+	<add key="LoginType" value="Hybrid"/>
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/Vermaat.Crm.Specflow/CrmTestingContext.cs
+++ b/Vermaat.Crm.Specflow/CrmTestingContext.cs
@@ -35,7 +35,7 @@ namespace Vermaat.Crm.Specflow
 
             _targets = ConfigurationManager.AppSettings["Target"]
                 .ToLower()
-                .Split(';')
+                .Split('_')
                 .Select(splitted => splitted.Trim())
                 .ToArray();
         }

--- a/Vermaat.Crm.Specflow/EasyRepro/TemporaryFixes.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/TemporaryFixes.cs
@@ -187,13 +187,13 @@ namespace Vermaat.Crm.Specflow.EasyRepro
             int attempts = 0;
             do
             {
-                success = ClickStaySignedIn(driver);
+                success = ClickStaySignedIn(driver) || WaitForMainPage(driver, 15);
                 attempts++;
             }
             while (!success && attempts <= 3);
 
             if (success)
-                WaitForMainPage(driver);
+                WaitForMainPage(driver, 60);
             else
                 throw new InvalidOperationException("Login failed");
 
@@ -225,7 +225,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
             return element != null;
         }
 
-        internal static bool WaitForMainPage(IWebDriver driver)
+        private static bool WaitForMainPage(IWebDriver driver, int timeout)
         {
             Action<IWebElement> successCallback = _ =>
                                   {
@@ -235,7 +235,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
                                   };
 
             var xpathToMainPage = By.XPath(Elements.Xpath[Reference.Login.CrmMainPage]);
-            var element = driver.WaitUntilAvailable(xpathToMainPage, TimeSpan.FromSeconds(60), successCallback);
+            var element = driver.WaitUntilAvailable(xpathToMainPage, TimeSpan.FromSeconds(timeout), successCallback);
             return element != null;
         }
 

--- a/Vermaat.Crm.Specflow/Vermaat.Crm.Specflow.csproj
+++ b/Vermaat.Crm.Specflow/Vermaat.Crm.Specflow.csproj
@@ -21,15 +21,15 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="Dynamics365.UIAutomation.Api" Version="9.1.0.23435" />
-    <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.21" />
-    <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.0.37" />
+    <PackageReference Include="Dynamics365.UIAutomation.Api" Version="9.1.0.27021" />
+    <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.29" />
+    <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.0.68" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="SpecFlow" Version="3.0.225" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="SpecFlow" Version="3.5.14" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Fixes an issue that in SpecFlow 3.5 targets split with a ';' don't work. See https://github.com/SpecFlowOSS/SpecFlow/issues/2261
* Fixed an issue where login would fail if there is no 'stay signed in' page
* Changed some pipelines so that everything works with clientids