### PR TITLE
clientid to appid to avoid confusion

### DIFF
--- a/Deployment/Scripts/UpdateAppSettings.ps1
+++ b/Deployment/Scripts/UpdateAppSettings.ps1
@@ -6,6 +6,7 @@ param(
 [string]$clientId,
 [string]$clientSecret,
 [string]$authType,
+[string]$appId,
 [string]$appsettingsPath
 )
 
@@ -41,5 +42,6 @@ Set-AppSetting -key "Password" -value $password
 Set-AppSetting -key "ClientId" -value $clientId
 Set-AppSetting -key "ClientSecret" -value $clientSecret
 Set-AppSetting -key "AuthType" -value $authType 
+Set-AppSetting -key "AppId" -value $appId
 
 $content.Save($fullPath)

--- a/Vermaat.Crm.Specflow.Sample/app.config
+++ b/Vermaat.Crm.Specflow.Sample/app.config
@@ -23,7 +23,7 @@
     <add key="AsyncJobTimeoutInSeconds" value="60" />
 	<add key="LoginType" value="OAuth"/>
 	<add key="RedirectUrl" value="app://58145B91-0C36-4500-8554-080854F2AC97"/>
-	<add key="ClientId" value="51f81489-12ee-4a9e-aaae-a2591f45987d" />
+	<add key="AppId" value="51f81489-12ee-4a9e-aaae-a2591f45987d" />
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/Vermaat.Crm.Specflow/Connectivity/OAuthCrmConnection.cs
+++ b/Vermaat.Crm.Specflow/Connectivity/OAuthCrmConnection.cs
@@ -26,7 +26,7 @@ namespace Vermaat.Crm.Specflow.Connectivity
             return new OAuthCrmConnection(
                 HelperMethods.GetAppSettingsValue("Username", false),
                 HelperMethods.GetAppSettingsValue("Password", false),
-                HelperMethods.GetAppSettingsValue("ClientId", false),
+                HelperMethods.GetAppSettingsValue("AppId", false),
                 HelperMethods.GetAppSettingsValue("RedirectUrl", false));
         }
 
@@ -35,7 +35,7 @@ namespace Vermaat.Crm.Specflow.Connectivity
             var userName = HelperMethods.GetAppSettingsValue("AdminUsername", true) ?? HelperMethods.GetAppSettingsValue("Username");
             var password = HelperMethods.GetAppSettingsValue("AdminPassword", true) ?? HelperMethods.GetAppSettingsValue("Password");
             return new OAuthCrmConnection(userName, password,
-                HelperMethods.GetAppSettingsValue("ClientId", false),
+                HelperMethods.GetAppSettingsValue("AppId", false),
                 HelperMethods.GetAppSettingsValue("RedirectUrl", false));
         }
 


### PR DESCRIPTION
Currently for both ClientSecret & OAuth the same variable 'ClientId' was used. This wasn't handy. Changed OAuth to AppId to also match the connectionstring