### PR TITLE
New functionality for wait until, activity parties and some fixes

### DIFF
--- a/Vermaat.Crm.Specflow.Sample/DataTypes/ActivityPartyDataType.feature
+++ b/Vermaat.Crm.Specflow.Sample/DataTypes/ActivityPartyDataType.feature
@@ -1,0 +1,22 @@
+﻿Feature: ActivityPartyDataType
+
+@API @Chrome @Firefox @Cleanup @Set2
+Scenario: Create Phonecall record
+	Given an account named TestAccount with the following values
+		| Property     | Value         |
+		| Account Name | ActivityParty |
+	And a related contact from TestAccount named ChildContact with the following values
+		| Property   | Value  |
+		| First Name | Child  |
+		| Last Name  | Record |
+	And the current logged in user named MyUser
+	When a phonecall named MyPhoneCall is created with the following values
+		| Property  | Value                     |
+		| Call From | MyUser                    |
+		| Call To   | TestAccount, ChildContact |
+		| Subject   | SpecFlow phonecall        |
+	Then MyPhoneCall has the following values
+		| Property  | Value                     |
+		| Call From | MyUser                    |
+		| Call To   | TestAccount, ChildContact |
+		| Subject   | SpecFlow phonecall        |

--- a/Vermaat.Crm.Specflow.Sample/General/DeleteData.feature
+++ b/Vermaat.Crm.Specflow.Sample/General/DeleteData.feature
@@ -17,6 +17,6 @@ Scenario: Delete a contact
 	Then TestAccount has the following values
 		| Property        | Value |
 		| Contact Deleted | Yes   |
-	And no contact exists with the following values
+	And within 30 seconds no contact exists with the following values
 		| Property     | Value       |
 		| Company Name | TestAccount |

--- a/Vermaat.Crm.Specflow.Sample/General/DeleteData.feature
+++ b/Vermaat.Crm.Specflow.Sample/General/DeleteData.feature
@@ -17,3 +17,6 @@ Scenario: Delete a contact
 	Then TestAccount has the following values
 		| Property        | Value |
 		| Contact Deleted | Yes   |
+	And no contact exists with the following values
+		| Property     | Value       |
+		| Company Name | TestAccount |

--- a/Vermaat.Crm.Specflow.Sample/General/UpdateData.feature
+++ b/Vermaat.Crm.Specflow.Sample/General/UpdateData.feature
@@ -3,25 +3,25 @@
 @API @Chrome @Firefox @Cleanup @SingleFilter @Set1
 Scenario: Update an existing Account
 Given an account named TestAccount with the following values
-	| Property     | Value                   |
-	| Account Name | DynamicHands            |
-	| Main Phone   | 0612345678              |
-	| Website      | https://dynamichands.nl |
-	| Industry     | Consulting              |
-	| Description  | Test multi line         |
+    | Property     | Value                   |
+    | Account Name | DynamicHands            |
+    | Main Phone   | 0612345678              |
+    | Website      | https://dynamichands.nl |
+    | Industry     | Consulting              |
+    | Description  | Test multi line         |
 When TestAccount is updated with the following values
-	| Property     | Value             |
-	| Account Name | DynamicHands B.V. |
-	| Main Phone   | 06987654321       |
-	| Fax          | 4839432324        |
-	| Description  | Update multi line |
+    | Property     | Value             |
+    | Account Name | DynamicHands B.V. |
+    | Main Phone   | 06987654321       |
+    | Fax          | 4839432324        |
+    | Description  | Update multi line |
 Then TestAccount has the following values
-	| Property     | Value                   |
-	| Account Name | DynamicHands B.V.       |
-	| Main Phone   | 06987654321             |
-	| Website      | https://dynamichands.nl |
-	| Industry     | Consulting              |
-	| Description  | Update multi line       |
+    | Property     | Value                   |
+    | Account Name | DynamicHands B.V.       |
+    | Main Phone   | 06987654321             |
+    | Website      | https://dynamichands.nl |
+    | Industry     | Consulting              |
+    | Description  | Update multi line       |
 
 @API @Chrome @Firefox @Cleanup @Set1
 Scenario: Basic contact test 
@@ -43,30 +43,30 @@ Then TestContact has the following values
 @API @Chrome @Firefox @Cleanup @Set1
 Scenario: Clearing values of Account
 Given an account named TestAccount with the following values
-	| Property     | Value                   |
-	| Account Name | DynamicHands            |
-	| Main Phone   | 0612345678              |
-	| Website      | https://dynamichands.nl |
-	| Industry     | Consulting              |
-	| Description  | Test multi line         |
+    | Property     | Value                   |
+    | Account Name | DynamicHands            |
+    | Main Phone   | 0612345678              |
+    | Website      | https://dynamichands.nl |
+    | Industry     | Consulting              |
+    | Description  | Test multi line         |
 When TestAccount is updated with the following values
-	| Property    | Value |
-	| Industry    |       |
-	| Website     |       |
-	| Description |       |
+    | Property    | Value |
+    | Industry    |       |
+    | Website     |       |
+    | Description |       |
 Then TestAccount has the following values
-	| Property     | Value        |
-	| Account Name | DynamicHands |
-	| Main Phone   | 0612345678   |
-	| Website      |              |
-	| Industry     |              |
-	| Description  |              |
+    | Property     | Value        |
+    | Account Name | DynamicHands |
+    | Main Phone   | 0612345678   |
+    | Website      |              |
+    | Industry     |              |
+    | Description  |              |
 
 @Chrome @Firefox @Cleanup @Set1
 Scenario: Setting Account Header Field
 Given an account named TestAccount with the following values
-	| Property       | Value |
-	| Annual Revenue | 5000  |
+    | Property       | Value |
+    | Annual Revenue | 5000  |
 Then TestAccount has the following values
-	| Property       | Value |
-	| Annual Revenue | 5000  |
+    | Property       | Value |
+    | Annual Revenue | 5000  |

--- a/Vermaat.Crm.Specflow.Sample/LocalizedTexts.json
+++ b/Vermaat.Crm.Specflow.Sample/LocalizedTexts.json
@@ -9,6 +9,7 @@
     "SaveButton": "Opslaan (Ctrl+S)",
     "SaveStatusSaving": "Bezig met opslaan",
     "SaveStatusUnsaved": "Niet-opgeslagen",
+    "QuickCreateViewRecord": "Record bekijken",
 
     // Below are localizations specific to the sample project. No need to copy these:
     "AccountSummaryTab": "Samenvatting",

--- a/Vermaat.Crm.Specflow.Sample/app.config
+++ b/Vermaat.Crm.Specflow.Sample/app.config
@@ -20,7 +20,7 @@
 		<add key="UCIOnly" value="true" />
 		<add key="TimeFormat" value="H:mm" />
 		<add key="DateFormat" value="d-M-yyyy" />
-		<add key="AsyncJobTimeoutInSeconds" value="60" />
+		<add key="AsyncJobTimeoutInSeconds" value="90" />
 		<add key="LoginType" value="OAuth"/>
 		<add key="RedirectUrl" value="app://58145B91-0C36-4500-8554-080854F2AC97"/>
 		<add key="AppId" value="51f81489-12ee-4a9e-aaae-a2591f45987d" />

--- a/Vermaat.Crm.Specflow/AssertHelper.cs
+++ b/Vermaat.Crm.Specflow/AssertHelper.cs
@@ -40,8 +40,34 @@ namespace Vermaat.Crm.Specflow
                 Assert.AreEqual(expected.Except(actual).Count(), 0, $"Expected Values: {string.Join(", ", expected)} | Actual Values: {string.Join(", ", actual)}");
                 Assert.AreEqual(actual.Except(expected).Count(), 0, $"Expected Values: {string.Join(", ", expected)} | Actual Values: {string.Join(", ", actual)}");
             }
+            else if(type == typeof(EntityCollection))
+            {
+                var expected = ParseEntityCollection((EntityCollection)expectedValue);
+                var actual = ParseEntityCollection((EntityCollection)actualValue);
+
+                Assert.AreEqual(expected.Length, actual.Length, $"Expected Values: {string.Join(", ", expected)} | Actual Values: {string.Join(", ", actual)}");
+                Assert.AreEqual(expected.Except(actual).Count(), 0, $"Expected Values: {string.Join(", ", expected)} | Actual Values: {string.Join(", ", actual)}");
+                Assert.AreEqual(actual.Except(expected).Count(), 0, $"Expected Values: {string.Join(", ", expected)} | Actual Values: {string.Join(", ", actual)}");
+            }
             else
                 Assert.AreEqual(expectedValue, actualValue, $"Field {attributeName} is different");
+        }
+
+        private static Guid[] ParseEntityCollection(EntityCollection col)
+        {
+            if (col == null || col.Entities == null || col.Entities.Count == 0)
+                return new Guid[0];
+
+            string entityName = col.EntityName ?? col.Entities[0]?.LogicalName;
+            if(!string.IsNullOrEmpty(entityName) && entityName.Equals("activityparty"))
+            {
+                return col.Entities.Select(e => e.GetAttributeValue<EntityReference>("partyid").Id).ToArray();
+            }
+            else
+            {
+                return col.Entities.Select(e => e.Id).ToArray();
+            } 
+                
         }
 
         /// <summary>

--- a/Vermaat.Crm.Specflow/Commands/LoginWithUserCommand.cs
+++ b/Vermaat.Crm.Specflow/Commands/LoginWithUserCommand.cs
@@ -14,7 +14,6 @@ namespace Vermaat.Crm.Specflow.Commands
     public class LoginWithUserCommand : ApiOnlyCommand
     {
         private readonly UserProfile _userProfile;
-        private readonly string _userAlias;
 
         public LoginWithUserCommand(CrmTestingContext crmContext, UserProfile userProfile)
             : base(crmContext)

--- a/Vermaat.Crm.Specflow/Commands/TryUntilCommand.cs
+++ b/Vermaat.Crm.Specflow/Commands/TryUntilCommand.cs
@@ -25,17 +25,22 @@ namespace Vermaat.Crm.Specflow.Commands
         public void Execute(CommandAction commandAction)
         {
             DateTime timeoutDateTime = DateTime.Now.Add(_timeout);
+            ExecuteUntil(timeoutDateTime, commandAction);
+            
+        }
 
+        private void ExecuteUntil(DateTime timeoutDateTime, CommandAction commandAction)
+        {
             try
             {
                 _crmContext.CommandProcessor.Execute(_childCommand, commandAction);
             }
-            catch(Exception)
+            catch (Exception)
             {
                 if (DateTime.Now < timeoutDateTime)
                 {
                     Thread.Sleep((int)_waitPeriod.TotalMilliseconds);
-                    Execute(commandAction);
+                    ExecuteUntil(timeoutDateTime, commandAction);
                 }
                 else
                     throw;
@@ -67,6 +72,11 @@ namespace Vermaat.Crm.Specflow.Commands
         {
             DateTime timeoutDateTime = DateTime.Now.Add(_timeout);
 
+            return ExecuteUntil(timeoutDateTime, commandAction);
+        }
+
+        private TResult ExecuteUntil(DateTime timeoutDateTime, CommandAction commandAction)
+        {
             try
             {
                 var result = _crmContext.CommandProcessor.Execute(_childCommand, commandAction);
@@ -76,7 +86,7 @@ namespace Vermaat.Crm.Specflow.Commands
                 else if (DateTime.Now < timeoutDateTime)
                 {
                     Thread.Sleep((int)_waitPeriod.TotalMilliseconds);
-                    return Execute(commandAction);
+                    return ExecuteUntil(timeoutDateTime, commandAction);
                 }
                 else
                     throw new TestExecutionException(Constants.ErrorCodes.TRYUNTIL_TIMEOUT, _timeoutMessageFunc(result));
@@ -87,7 +97,7 @@ namespace Vermaat.Crm.Specflow.Commands
                 if (DateTime.Now < timeoutDateTime)
                 {
                     Thread.Sleep((int)_waitPeriod.TotalMilliseconds);
-                    return Execute(commandAction);
+                    return ExecuteUntil(timeoutDateTime, commandAction);
                 }
                 else
                     throw;

--- a/Vermaat.Crm.Specflow/Commands/TryUntilCommand.cs
+++ b/Vermaat.Crm.Specflow/Commands/TryUntilCommand.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Vermaat.Crm.Specflow.Commands
+{
+    public class TryUntilCommand<TCommand> : ICommand where TCommand : ICommand
+    {
+        private readonly CrmTestingContext _crmContext;
+        private readonly TCommand _childCommand;
+        private readonly TimeSpan _timeout;
+        private readonly TimeSpan _waitPeriod;
+
+        public TryUntilCommand(CrmTestingContext crmContext, TCommand childCommand, TimeSpan timeout, TimeSpan waitPeriod)
+        {
+            _crmContext = crmContext;
+            _childCommand = childCommand;
+            _timeout = timeout;
+            _waitPeriod = waitPeriod;
+        }
+
+        public void Execute(CommandAction commandAction)
+        {
+            DateTime timeoutDateTime = DateTime.Now.Add(_timeout);
+
+            try
+            {
+                _crmContext.CommandProcessor.Execute(_childCommand, commandAction);
+            }
+            catch(Exception)
+            {
+                if (DateTime.Now < timeoutDateTime)
+                {
+                    Thread.Sleep((int)_waitPeriod.TotalMilliseconds);
+                    Execute(commandAction);
+                }
+                else
+                    throw;
+            }
+        }
+    }
+
+    public class TryUntilCommandFunc<TCommand, TResult> : ICommandFunc<TResult> where TCommand : ICommandFunc<TResult>
+    {
+        private readonly CrmTestingContext _crmContext;
+        private readonly TCommand _childCommand;
+        private readonly TimeSpan _timeout;
+        private readonly TimeSpan _waitPeriod;
+        private readonly Func<TResult, bool> _assertResultValid;
+        private readonly Func<TResult, string> _timeoutMessageFunc;
+
+        public TryUntilCommandFunc(CrmTestingContext crmContext, TCommand childCommand, TimeSpan timeout,
+            TimeSpan waitPeriod, Func<TResult, bool> assertResultValid, Func<TResult, string> timeoutMessageFunc)
+        {
+            _crmContext = crmContext;
+            _childCommand = childCommand;
+            _timeout = timeout;
+            _waitPeriod = waitPeriod;
+            _assertResultValid = assertResultValid;
+            _timeoutMessageFunc = timeoutMessageFunc;
+        }
+
+        public TResult Execute(CommandAction commandAction)
+        {
+            DateTime timeoutDateTime = DateTime.Now.Add(_timeout);
+
+            try
+            {
+                var result = _crmContext.CommandProcessor.Execute(_childCommand, commandAction);
+
+                if (_assertResultValid(result))
+                    return result;
+                else if (DateTime.Now < timeoutDateTime)
+                {
+                    Thread.Sleep((int)_waitPeriod.TotalMilliseconds);
+                    return Execute(commandAction);
+                }
+                else
+                    throw new TestExecutionException(Constants.ErrorCodes.TRYUNTIL_TIMEOUT, _timeoutMessageFunc(result));
+
+            }
+            catch (Exception)
+            {
+                if (DateTime.Now < timeoutDateTime)
+                {
+                    Thread.Sleep((int)_waitPeriod.TotalMilliseconds);
+                    return Execute(commandAction);
+                }
+                else
+                    throw;
+            }
+        }
+    }
+}

--- a/Vermaat.Crm.Specflow/Constants.cs
+++ b/Vermaat.Crm.Specflow/Constants.cs
@@ -89,6 +89,7 @@ namespace Vermaat.Crm.Specflow
             public const string SaveStatusUnsaved = "SaveStatusUnsaved";
             public const string CloseAsWon = "CloseAsWon";
             public const string CloseAsLost = "CloseAsLost";
+            public const string QuickCreateViewRecord = "View Record";
         }
     }
 }

--- a/Vermaat.Crm.Specflow/Constants.cs
+++ b/Vermaat.Crm.Specflow/Constants.cs
@@ -75,6 +75,7 @@ namespace Vermaat.Crm.Specflow
             public const int LOCALIZATION_OVERRIDES_NOT_FOUND = 43;
             public const int USERPROFILE_NOT_FOUND = 44;
             public const int USERPROFILE_FILE_NOT_FOUND = 45;
+            public const int TRYUNTIL_TIMEOUT = 45;
         }
 
         public class LocalizedTexts

--- a/Vermaat.Crm.Specflow/Constants.cs
+++ b/Vermaat.Crm.Specflow/Constants.cs
@@ -75,7 +75,7 @@ namespace Vermaat.Crm.Specflow
             public const int LOCALIZATION_OVERRIDES_NOT_FOUND = 43;
             public const int USERPROFILE_NOT_FOUND = 44;
             public const int USERPROFILE_FILE_NOT_FOUND = 45;
-            public const int TRYUNTIL_TIMEOUT = 45;
+            public const int TRYUNTIL_TIMEOUT = 46;
         }
 
         public class LocalizedTexts

--- a/Vermaat.Crm.Specflow/EasyRepro/Fields/BodyFormField.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/Fields/BodyFormField.cs
@@ -2,6 +2,7 @@
 using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
 using Microsoft.Dynamics365.UIAutomation.Browser;
 using Microsoft.Xrm.Sdk.Metadata;
+using Newtonsoft.Json.Linq;
 using OpenQA.Selenium;
 using System;
 using System.Collections.Generic;
@@ -113,6 +114,28 @@ namespace Vermaat.Crm.Specflow.EasyRepro.Fields
             else
             {
                 App.App.Entity.ClearValue(value.ToLookupItem(Metadata));
+            }
+        }
+
+        protected override void SetLookupValues(LookupValue[] values)
+        {
+            var lookupValues = new List<string>();
+            foreach(var value in values)
+            {
+                if(value.Value != null)
+                {
+                    lookupValues.Add($"{{ id: '{value.Value.Id}', name: '{value.Value.Name?.Replace("'", @"\'")}', entityType: '{value.Value.LogicalName}' }}");
+                }
+            }
+
+            if (lookupValues.Count > 0)
+            {
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').setValue([ {string.Join(", ",lookupValues)} ])");
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').fireOnChange()");
+            }
+            else
+            {
+                App.App.Entity.ClearValue(new LookupItem() { Name = Metadata.LogicalName });
             }
         }
     }

--- a/Vermaat.Crm.Specflow/EasyRepro/Fields/Field.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/Fields/Field.cs
@@ -63,6 +63,9 @@ namespace Vermaat.Crm.Specflow.EasyRepro.Fields
                 case AttributeTypeCode.Decimal:
                     SetDecimalField(new DecimalValue((decimal?)fieldValue));
                     break;
+                case AttributeTypeCode.PartyList:
+                    SetLookupValues(((EntityCollection)fieldValue).Entities.Select(e => new LookupValue(e.GetAttributeValue<EntityReference>("partyid"))).ToArray());
+                    break;
                 default:
                     SetTextField((string)fieldValue);
                     break;
@@ -99,6 +102,8 @@ namespace Vermaat.Crm.Specflow.EasyRepro.Fields
         protected abstract void SetTextField(string fieldValue);
 
         protected abstract void SetLookupValue(LookupValue value);
+
+        protected abstract void SetLookupValues(LookupValue[] values);
 
         protected abstract void SetMultiSelectOptionSetField(MultiSelectOptionSetValue value);
 

--- a/Vermaat.Crm.Specflow/EasyRepro/Fields/HeaderFormField.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/Fields/HeaderFormField.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
+﻿using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
 using Microsoft.Dynamics365.UIAutomation.Browser;
 using Microsoft.Xrm.Sdk.Metadata;
 using System;
@@ -62,6 +63,28 @@ namespace Vermaat.Crm.Specflow.EasyRepro.Fields
             else
             {
                 App.App.Entity.ClearValue(value.ToLookupItem(Metadata));
+            }
+        }
+
+        protected override void SetLookupValues(LookupValue[] values)
+        {
+            var lookupValues = new List<string>();
+            foreach (var value in values)
+            {
+                if (value.Value != null)
+                {
+                    lookupValues.Add($"{{ id: '{value.Value.Id}', name: '{value.Value.Name?.Replace("'", @"\'")}', entityType: '{value.Value.LogicalName}' }}");
+                }
+            }
+
+            if (lookupValues.Count > 0)
+            {
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').setValue([ {string.Join(", ", lookupValues)} ])");
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').fireOnChange()");
+            }
+            else
+            {
+                App.App.Entity.ClearValue(new LookupItem() { Name = Metadata.LogicalName });
             }
         }
 

--- a/Vermaat.Crm.Specflow/EasyRepro/Fields/OpportunityCloseDialogField.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/Fields/OpportunityCloseDialogField.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Dynamics365.UIAutomation.Api.UCI;
 using Microsoft.Dynamics365.UIAutomation.Api.UCI.DTO;
 using Microsoft.Dynamics365.UIAutomation.Browser;
 using Microsoft.Xrm.Sdk.Metadata;
@@ -94,6 +95,28 @@ namespace Vermaat.Crm.Specflow.EasyRepro.Fields
                 App.App.Entity.ClearValue(value.ToLookupItem(Metadata));
             }
         }
-        
+
+        protected override void SetLookupValues(LookupValue[] values)
+        {
+            var lookupValues = new List<string>();
+            foreach (var value in values)
+            {
+                if (value.Value != null)
+                {
+                    lookupValues.Add($"{{ id: '{value.Value.Id}', name: '{value.Value.Name?.Replace("'", @"\'")}', entityType: '{value.Value.LogicalName}' }}");
+                }
+            }
+
+            if (lookupValues.Count > 0)
+            {
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').setValue([ {string.Join(", ", lookupValues)} ])");
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').fireOnChange()");
+            }
+            else
+            {
+                App.App.Entity.ClearValue(new LookupItem() { Name = Metadata.LogicalName });
+            }
+        }
+
     }
 }

--- a/Vermaat.Crm.Specflow/EasyRepro/Fields/QuickCreateBodyFormField.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/Fields/QuickCreateBodyFormField.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Dynamics365.UIAutomation.Browser;
+﻿using Microsoft.Dynamics365.UIAutomation.Api.UCI;
+using Microsoft.Dynamics365.UIAutomation.Browser;
 using Microsoft.Xrm.Sdk.Metadata;
+using System.Collections.Generic;
 using Vermaat.Crm.Specflow.EasyRepro.FieldTypes;
 
 namespace Vermaat.Crm.Specflow.EasyRepro.Fields
@@ -79,6 +81,28 @@ namespace Vermaat.Crm.Specflow.EasyRepro.Fields
             else
             {
                 App.App.QuickCreate.ClearValue(value.ToLookupItem(Metadata));
+            }
+        }
+
+        protected override void SetLookupValues(LookupValue[] values)
+        {
+            var lookupValues = new List<string>();
+            foreach (var value in values)
+            {
+                if (value.Value != null)
+                {
+                    lookupValues.Add($"{{ id: '{value.Value.Id}', name: '{value.Value.Name?.Replace("'", @"\'")}', entityType: '{value.Value.LogicalName}' }}");
+                }
+            }
+
+            if (lookupValues.Count > 0)
+            {
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').setValue([ {string.Join(", ", lookupValues)} ])");
+                App.WebDriver.ExecuteScript($"Xrm.Page.getAttribute('{LogicalName}').fireOnChange()");
+            }
+            else
+            {
+                App.App.Entity.ClearValue(new LookupItem() { Name = Metadata.LogicalName });
             }
         }
     }

--- a/Vermaat.Crm.Specflow/EasyRepro/QuickFormData.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/QuickFormData.cs
@@ -103,7 +103,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
                 var saveCompleted = false;
                 while (!saveCompleted && DateTime.Now < timeout)
                 {
-                    if (driver.HasElement(SeleniumFunctions.Selectors.GetXPathSeleniumSelector(SeleniumSelectorItems.Entity_QuickCreate_OpenChildButton)))
+                    if (HasViewRecordButton(driver))
                         saveCompleted = true;
                     else
                     {
@@ -115,7 +115,6 @@ namespace Vermaat.Crm.Specflow.EasyRepro
                         Logger.WriteLine("Save not yet completed. Waiting..");
                         Thread.Sleep(250);
                     }
-
                 }
 
                 if (!saveCompleted)
@@ -123,6 +122,11 @@ namespace Vermaat.Crm.Specflow.EasyRepro
 
                 return true;
             });
+        }
+
+        private bool HasViewRecordButton(IWebDriver driver)
+        {
+            return driver.HasElement(SeleniumFunctions.Selectors.GetXPathSeleniumSelector(SeleniumSelectorItems.Entity_QuickCreate_Notification_Window));
         }
 
         public bool IsItQuickCreate()

--- a/Vermaat.Crm.Specflow/EasyRepro/QuickFormData.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/QuickFormData.cs
@@ -53,8 +53,9 @@ namespace Vermaat.Crm.Specflow.EasyRepro
         {
             _app.Client.Execute(BrowserOptionHelper.GetOptions("Open Quick Create Child"), (driver) =>
                 {
-                    driver.WaitUntilClickable(
-                        SeleniumFunctions.Selectors.GetXPathSeleniumSelector(SeleniumSelectorItems.Entity_QuickCreate_OpenChildButton),
+                    var window = driver.FindElement(SeleniumFunctions.Selectors.GetXPathSeleniumSelector(SeleniumSelectorItems.Entity_QuickCreate_Notification_Window));
+                    window.WaitUntilClickable(
+                        SeleniumFunctions.Selectors.GetXPathSeleniumSelector(SeleniumSelectorItems.Entity_QuickCreate_OpenChildButton, _app.LocalizedTexts[Constants.LocalizedTexts.QuickCreateViewRecord, _app.UILanguageCode]),
                         TimeSpan.FromSeconds(5),
                         null,
                         () => throw new TestExecutionException(Constants.ErrorCodes.QUICK_CREATE_CHILD_NOT_AVAILABLE)).Click();
@@ -103,7 +104,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
                 var saveCompleted = false;
                 while (!saveCompleted && DateTime.Now < timeout)
                 {
-                    if (HasViewRecordButton(driver))
+                    if (driver.HasElement(SeleniumFunctions.Selectors.GetXPathSeleniumSelector(SeleniumSelectorItems.Entity_QuickCreate_Notification_Window)))
                         saveCompleted = true;
                     else
                     {
@@ -122,11 +123,6 @@ namespace Vermaat.Crm.Specflow.EasyRepro
 
                 return true;
             });
-        }
-
-        private bool HasViewRecordButton(IWebDriver driver)
-        {
-            return driver.HasElement(SeleniumFunctions.Selectors.GetXPathSeleniumSelector(SeleniumSelectorItems.Entity_QuickCreate_Notification_Window));
         }
 
         public bool IsItQuickCreate()

--- a/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
@@ -21,7 +21,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
             { SeleniumSelectorItems.Entity_FormNotifcation_NotificationTypeIcon, ".//span[contains(@id,'notification_icon_')]" },
             { SeleniumSelectorItems.Entity_FormNotification_NotificationMessage, ".//span[@data-id='warningNotification']" },
             { SeleniumSelectorItems.Entity_QuickCreate_Notification_Window, "//div[contains(@data-id,'ToastNotification_quickcreate')]" },
-            { SeleniumSelectorItems.Entity_QuickCreate_OpenChildButton, "//a[@data-id='notification-ViewRecord']" },
+            { SeleniumSelectorItems.Entity_QuickCreate_OpenChildButton, ".//p[text() = '[NAME]']" },
             { SeleniumSelectorItems.Entity_SaveStatus, "//span[@data-id='header_saveStatus']" },
             { SeleniumSelectorItems.Entity_SubGrid, "//div[@id=\"dataSetRoot_[NAME]\"]" },
             { SeleniumSelectorItems.Entity_SubGrid_ButtonList, ".//ul[@data-id='CommandBar']" },

--- a/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
@@ -20,7 +20,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
             { SeleniumSelectorItems.Entity_FormNotifcation_NotificationList, ".//ul[@data-id='notificationList']" },
             { SeleniumSelectorItems.Entity_FormNotifcation_NotificationTypeIcon, ".//span[contains(@id,'notification_icon_')]" },
             { SeleniumSelectorItems.Entity_FormNotification_NotificationMessage, ".//span[@data-id='warningNotification']" },
-            { SeleniumSelectorItems.Entity_QuickCreate_Notification_Window, "//div[contains(@data-id,'ToastNotification_quickcreate')" },
+            { SeleniumSelectorItems.Entity_QuickCreate_Notification_Window, "//div[contains(@data-id,'ToastNotification_quickcreate')]" },
             { SeleniumSelectorItems.Entity_QuickCreate_OpenChildButton, "//a[@data-id='notification-ViewRecord']" },
             { SeleniumSelectorItems.Entity_SaveStatus, "//span[@data-id='header_saveStatus']" },
             { SeleniumSelectorItems.Entity_SubGrid, "//div[@id=\"dataSetRoot_[NAME]\"]" },

--- a/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/SeleniumSelectorData.cs
@@ -20,6 +20,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro
             { SeleniumSelectorItems.Entity_FormNotifcation_NotificationList, ".//ul[@data-id='notificationList']" },
             { SeleniumSelectorItems.Entity_FormNotifcation_NotificationTypeIcon, ".//span[contains(@id,'notification_icon_')]" },
             { SeleniumSelectorItems.Entity_FormNotification_NotificationMessage, ".//span[@data-id='warningNotification']" },
+            { SeleniumSelectorItems.Entity_QuickCreate_Notification_Window, "//div[contains(@data-id,'ToastNotification_quickcreate')" },
             { SeleniumSelectorItems.Entity_QuickCreate_OpenChildButton, "//a[@data-id='notification-ViewRecord']" },
             { SeleniumSelectorItems.Entity_SaveStatus, "//span[@data-id='header_saveStatus']" },
             { SeleniumSelectorItems.Entity_SubGrid, "//div[@id=\"dataSetRoot_[NAME]\"]" },

--- a/Vermaat.Crm.Specflow/ErrorCodes.cs
+++ b/Vermaat.Crm.Specflow/ErrorCodes.cs
@@ -62,6 +62,7 @@ namespace Vermaat.Crm.Specflow
             AddError(Constants.ErrorCodes.LOCALIZATION_OVERRIDES_NOT_FOUND, "Localization JSON file not found at: {0}");
             AddError(Constants.ErrorCodes.USERPROFILE_NOT_FOUND, "User profile '{0}' doesn't exist");
             AddError(Constants.ErrorCodes.USERPROFILE_FILE_NOT_FOUND, "User profile file '{0}' doesn't exist");
+            AddError(Constants.ErrorCodes.TRYUNTIL_TIMEOUT, "Timeout for retry reached: {0}");
         }
 
         public void AddError(int errorCode, string message)

--- a/Vermaat.Crm.Specflow/HelperMethods.cs
+++ b/Vermaat.Crm.Specflow/HelperMethods.cs
@@ -86,6 +86,10 @@ namespace Vermaat.Crm.Specflow
             {
                 return ((OptionSetValueCollection)value).Where(ov => ov != null).Select(ov => ov.Value);
             }
+            else if (type == typeof(EntityCollection))
+            {
+                return ((EntityCollection)value)?.Entities?.Where(en => en != null).Select(en => en.Id);
+            }
             return value;
         }
 

--- a/Vermaat.Crm.Specflow/Hooks.cs
+++ b/Vermaat.Crm.Specflow/Hooks.cs
@@ -163,6 +163,13 @@ namespace Vermaat.Crm.Specflow
             }
         }
 
+        [BeforeTestRun]
+        public static void BeforeTestRunXPathFixes()
+        {
+            AppElements.Xpath[AppReference.Dialogs.ConfirmButton] = "//button[@data-id='confirmButton']";
+            AppElements.Xpath[AppReference.Dialogs.CancelButton] = "//button[@data-id='cancelButton']";
+        }
+
         [AfterTestRun]
         public static void AfterTestRunCleanup()
         {

--- a/Vermaat.Crm.Specflow/LocalizedTexts.cs
+++ b/Vermaat.Crm.Specflow/LocalizedTexts.cs
@@ -55,7 +55,7 @@ namespace Vermaat.Crm.Specflow
 
             var localizedTextSet = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(File.ReadAllText(fileInfo.FullName), settings);
 
-            foreach(var key in localizedTextSet.Keys.ToArray())
+            foreach (var key in localizedTextSet.Keys.ToArray())
             {
                 localizedTextSet[key] = MergeObjects(GetDefaults(), localizedTextSet[key]);
             }
@@ -65,7 +65,7 @@ namespace Vermaat.Crm.Specflow
 
         private Dictionary<string, string> MergeObjects(Dictionary<string, string> localizedTexts, Dictionary<string, string> overrides)
         {
-            foreach(var item in overrides)
+            foreach (var item in overrides)
             {
                 if (localizedTexts.ContainsKey(item.Key))
                     localizedTexts[item.Key] = item.Value;
@@ -87,6 +87,7 @@ namespace Vermaat.Crm.Specflow
                 { Constants.LocalizedTexts.SaveButton, "Save (CTRL+S)" },
                 { Constants.LocalizedTexts.SaveStatusSaving, "saving" },
                 { Constants.LocalizedTexts.SaveStatusUnsaved, "unsaved" },
+                { Constants.LocalizedTexts.QuickCreateViewRecord, "View Record" },
             };
     }
 }

--- a/Vermaat.Crm.Specflow/MetadataCache.cs
+++ b/Vermaat.Crm.Specflow/MetadataCache.cs
@@ -47,7 +47,15 @@ namespace Vermaat.Crm.Specflow
             if (attributeMd.Length == 0)
                 throw new TestExecutionException(Constants.ErrorCodes.ATTRIBUTE_DOESNT_EXIST, displayName, entityName);
             else if (attributeMd.Length > 1)
-                throw new TestExecutionException(Constants.ErrorCodes.MULTIPLE_ATTRIBUTES_FOUND, displayName, string.Join(", ", attributeMd.Select(md => md.LogicalName)));
+            {
+                // If multiple attributes are found, but one matches the logical name. Always take the logical name
+                var logicalNameOnly = attributeMd.FirstOrDefault(a => a.LogicalName.Equals(displayName));
+                if (logicalNameOnly != null)
+                    return logicalNameOnly;
+                else
+                    throw new TestExecutionException(Constants.ErrorCodes.MULTIPLE_ATTRIBUTES_FOUND, displayName, string.Join(", ", attributeMd.Select(md => md.LogicalName)));
+
+            }
 
             return attributeMd.First();
 

--- a/Vermaat.Crm.Specflow/Steps/GeneralSteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/GeneralSteps.cs
@@ -138,7 +138,7 @@ namespace Vermaat.Crm.Specflow.Steps
             _crmContext.CommandProcessor.Execute(new AssertBusinessProcessStageCommand(_crmContext, alias, stageName));
         }
 
-        [Then(@"(.*) has the following values")]
+        [Then(@"([^\s]+) has the following values")]
         public void ThenAliasHasValues(string alias, Table criteria)
         {
             EntityReference aliasRef = _crmContext.RecordCache[alias];

--- a/Vermaat.Crm.Specflow/Steps/GeneralSteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/GeneralSteps.cs
@@ -23,7 +23,7 @@ namespace Vermaat.Crm.Specflow.Steps
 
         #region Given
 
-        [Given(@"an existing ([^\s]+) named (.*) with the following values")]
+        [Given(@"an existing ([^\s]+) named ([^\s]+) with the following values")]
         public void GivenExistingWithValues(string entityName, string alias, Table criteria)
         {
             Entity entity = ThenRecordExists(entityName, criteria);

--- a/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
@@ -23,6 +23,19 @@ namespace Vermaat.Crm.Specflow.Steps
             _seleniumContext = seleniumContext;
         }
 
+        #region Given
+
+        [Given(@"an existing ([^\s]+) named ([^\s]+) with the following values is available within ([0-9]+) seconds")]
+        public void GivenExistingWithValues(string entityName, string alias, int seconds, Table criteria)
+        {
+            Entity entity = ThenRecordExists(seconds, entityName, criteria);
+            _crmContext.RecordCache.Add(alias, entity, false);
+        }
+
+        #endregion
+
+        #region Then
+
         [Then(@"within ([0-9]+) seconds ([^\s]+) has the following values")]
         public void ThenAliasHasValues(int seconds, string alias, Table criteria)
         {
@@ -48,6 +61,8 @@ namespace Vermaat.Crm.Specflow.Steps
                 r => r.Count == amount,
                 r => $"When looking for records for {entityName}, expected {amount}, but found {r.Count} records");
         }
+
+        #endregion
 
         private void TryUntil<TCommand>(TCommand command, int seconds) where TCommand : ICommand
         {

--- a/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
@@ -38,7 +38,7 @@ namespace Vermaat.Crm.Specflow.Steps
             return ThenRecordCountExists(seconds, 1, entityName, criteria)[0];
         }
 
-        [Then(@"within ([0-9]+) seconds([0-9]+) ([^\s]+) records exist with the following values")]
+        [Then(@"within ([0-9]+) seconds ([0-9]+) ([^\s]+) records exist with the following values")]
         public DataCollection<Entity> ThenRecordCountExists(int seconds, int amount, string entityName, Table criteria)
         {
             _crmContext.TableConverter.ConvertTable(entityName, criteria);

--- a/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
@@ -1,0 +1,62 @@
+﻿using Azure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TechTalk.SpecFlow;
+using Vermaat.Crm.Specflow.Commands;
+
+namespace Vermaat.Crm.Specflow.Steps
+{
+    public class TryUntilSteps
+    {
+        private readonly CrmTestingContext _crmContext;
+        private readonly SeleniumTestingContext _seleniumContext;
+
+        public TryUntilSteps(CrmTestingContext crmContext, SeleniumTestingContext seleniumContext)
+        {
+            _crmContext = crmContext;
+            _seleniumContext = seleniumContext;
+        }
+
+        [Then(@"within ([0-9]+) seconds ([^\s]+) has the following values")]
+        public void ThenAliasHasValues(int seconds, string alias, Table criteria)
+        {
+            EntityReference aliasRef = _crmContext.RecordCache[alias];
+            _crmContext.TableConverter.ConvertTable(aliasRef.LogicalName, criteria);
+
+            TryUntil(new AssertCrmRecordCommand(_crmContext, aliasRef, criteria), seconds);
+        }
+
+        [Then(@"within ([0-9]+) seconds a ([^\s]+) exists with the following values")]
+        [Then(@"within ([0-9]+) seconds an ([^\s]+) exists with the following values")]
+        public Entity ThenRecordExists(int seconds, string entityName, Table criteria)
+        {
+            return ThenRecordCountExists(seconds, 1, entityName, criteria)[0];
+        }
+
+        [Then(@"within ([0-9]+) seconds([0-9]+) ([^\s]+) records exist with the following values")]
+        public DataCollection<Entity> ThenRecordCountExists(int seconds, int amount, string entityName, Table criteria)
+        {
+            _crmContext.TableConverter.ConvertTable(entityName, criteria);
+
+            return TryUntil<GetRecordsCommand, DataCollection<Entity>>(new GetRecordsCommand(_crmContext, entityName, criteria), seconds, 
+                r => r.Count == amount,
+                r => $"When looking for records for {entityName}, expected {amount}, but found {r.Count} records");
+        }
+
+        private void TryUntil<TCommand>(TCommand command, int seconds) where TCommand : ICommand
+        {
+            _crmContext.CommandProcessor.Execute(new TryUntilCommand<TCommand>(_crmContext, command, TimeSpan.FromSeconds(seconds), TimeSpan.FromSeconds(5)));
+        }
+
+        private TResult TryUntil<TCommand, TResult>(TCommand command, int seconds, Func<TResult, bool> assertFunc, Func<TResult,string> timeoutMessageFunc) where TCommand : ICommandFunc<TResult>
+        {
+            return _crmContext.CommandProcessor.Execute(new TryUntilCommandFunc<TCommand, TResult>(_crmContext, command, 
+                TimeSpan.FromSeconds(seconds), TimeSpan.FromSeconds(5), assertFunc, timeoutMessageFunc));
+        }
+    }
+}

--- a/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
@@ -11,6 +11,7 @@ using Vermaat.Crm.Specflow.Commands;
 
 namespace Vermaat.Crm.Specflow.Steps
 {
+    [Binding]
     public class TryUntilSteps
     {
         private readonly CrmTestingContext _crmContext;

--- a/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/TryUntilSteps.cs
@@ -52,6 +52,12 @@ namespace Vermaat.Crm.Specflow.Steps
             return ThenRecordCountExists(seconds, 1, entityName, criteria)[0];
         }
 
+        [Then(@"within ([0-9]+) seconds no ([^\s]+) exists with the following values")]
+        public void ThenNoRecordExists(int seconds, string entityName, Table criteria)
+        {
+            ThenRecordCountExists(seconds, 0, entityName, criteria);
+        }
+
         [Then(@"within ([0-9]+) seconds ([0-9]+) ([^\s]+) records exist with the following values")]
         public DataCollection<Entity> ThenRecordCountExists(int seconds, int amount, string entityName, Table criteria)
         {


### PR DESCRIPTION
* Added new steps:
  * Given an existing {entityName} named {alias} with the following values is available within X seconds 
  * Then within X seconds {alias} has the following values
  * Then within X seconds a {entityName} exists with the following values
  * Then within X seconds an {entityName} exists with the following values
  * Then within X seconds no {entityName} exists with the following values
  * Then within X seconds Y {entityName} records exist with the following values
* Fixed an issue that when the display name of a column matches the logical name it caused an error. In this case now the logical name is always chosen
* Fixed an issue that the HTML code regarding opening a quick created record was changed causing the step to fail
* Fixed an issue that the HTML code regarding confirmation dialogs was changed causing all steps using confirm dialogs to fail (like delete records)