### PR TITLE
Feature/localized error messages

### DIFF
--- a/Deployment/Pipelines/Template_Build.yml
+++ b/Deployment/Pipelines/Template_Build.yml
@@ -5,7 +5,7 @@ steps:
 - task: NuGetToolInstaller@0
   displayName: 'Use NuGet 5.0.0'
   inputs:
-    versionSpec: 5.0.0
+    versionSpec: 6.5.0
 
 - task: NuGetCommand@2
   displayName: NuGet Restore

--- a/Vermaat.Crm.Specflow.Sample/Users.json
+++ b/Vermaat.Crm.Specflow.Sample/Users.json
@@ -2,10 +2,10 @@
   {
     "Profile": "Salesperson",
     "MFA": false,
-    "Username": "TestUser1@vermaat16.onmicrosoft.com"
+    "Username": "TestUser1@vermaat21.onmicrosoft.com"
   },
   {
     "Profile": "Manager",
-    "Username": "TestUser2@vermaat16.onmicrosoft.com"
+    "Username": "TestUser2@vermaat21.onmicrosoft.com"
   }
 ]

--- a/Vermaat.Crm.Specflow/EasyRepro/Fields/FormXmlParser.cs
+++ b/Vermaat.Crm.Specflow/EasyRepro/Fields/FormXmlParser.cs
@@ -57,7 +57,7 @@ namespace Vermaat.Crm.Specflow.EasyRepro.Fields
 
             foreach (var tab in definition.Tabs)
             {
-                context.TabName = tab.Name;
+                context.TabName = tab.Name ?? tab.Id;
                 context.TabLabel = tab.Labels.GetLabelInLanguage(app.UILanguageCode, GlobalTestingContext.LanguageCode);
                 foreach (var column in tab.Columns)
                 {

--- a/Vermaat.Crm.Specflow/Entities/FormXmlDefinition.cs
+++ b/Vermaat.Crm.Specflow/Entities/FormXmlDefinition.cs
@@ -58,6 +58,9 @@ namespace Vermaat.Crm.Specflow.Entities
     [XmlType(AnonymousType = true)]
     public class FormTab
     {
+        [XmlAttribute("id")]
+        public string Id { get; set; }
+
         [XmlAttribute("name")]
         public string Name { get; set; }
 

--- a/Vermaat.Crm.Specflow/Steps/UISteps.cs
+++ b/Vermaat.Crm.Specflow/Steps/UISteps.cs
@@ -3,6 +3,7 @@ using Microsoft.Dynamics365.UIAutomation.Browser;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -67,6 +68,12 @@ namespace Vermaat.Crm.Specflow.Steps
         public void ThenErrorAppears(string errorMessage)
         {
             _crmContext.CommandProcessor.Execute(new AssertErrorDialogCommand(_crmContext, _seleniumContext, errorMessage));
+        }
+
+        [Then(@"the following localized error message appears: '(.*)'")]
+        public void ThenLocalizedErrorAppears(string errorMessage)
+        {
+            ThenErrorAppears(GlobalTestingContext.LocalizedTexts[errorMessage, GlobalTestingContext.ConnectionManager.CurrentConnection.UserSettings.UILanguage]);
         }
 
         [Then("(.*)'s form has the following ribbon state")]


### PR DESCRIPTION
* Added step 'Then the following localized error message appears: '(.*)'